### PR TITLE
Add info on Gulp and Node compatibility issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
  * Note: It works on macOS only.
 
-## Note
+## Compatability
 
 Gulp v3 is incompatible with Node v12. As a result if your Gulp and Node versions are equal to the above mentioned ones, you will be unable to successfully run `npm install`.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
  * Note: It works on macOS only.
 
+## Note
+
+Gulp v3 is incompatible with Node v12. As a result if your Gulp and Node versions are equal to the above mentioned ones, you will be unable to successfully run `npm install`.
+
+See [this Stack Overflow thread](https://stackoverflow.com/a/55926692/2694800) for more details
+
+Two workarounds:
+
++ Upgrade to Gulp 4
++ Downgrade Node to an earlier version
+  + The simplest way to do this is with [nvm](https://github.com/nvm-sh/nvm)
+
 ## Install
 
 ```


### PR DESCRIPTION
This PR adds a section detailing compatibility issues between Gulp 3 and Node 12 and advice on how to fix the problem in case someone else runs into the same situation when attempting to call `npm install` on this package.