### PR TITLE
Force electron dark mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,5 +13,6 @@ module.exports = {
     }
   },
   deactivate() {
+    remote.nativeTheme.themeSource = 'system'
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,9 @@
+const remote = require('@electron/remote')
+
 module.exports = {
-  activate () {
+  activate() {
+    remote.nativeTheme.themeSource = 'dark'
+
     const acrylicEnabled = inkdrop.config.get('core.mainWindow.acrylicEnabled')
     if (!acrylicEnabled) {
       inkdrop.notifications.addError('Acrylic background not enabled', {
@@ -8,6 +12,6 @@ module.exports = {
       })
     }
   },
-  deactivate () {
+  deactivate() {
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "vibrant-dark-ui",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "MIT",
       "devDependencies": {
         "better-console": "^1.0.1",


### PR DESCRIPTION
Fixed an issue where the entire app would appear bright when the OS theme is set to light mode.

**Before**:

https://github.com/inkdropapp/vibrant-dark-ui/assets/39664774/d3897522-18d1-45e1-a8d2-747ecbb3af07

**After**:

https://github.com/inkdropapp/vibrant-dark-ui/assets/39664774/f477ffae-667c-4f7b-8613-0ae5c94ab919